### PR TITLE
Add generated dependency files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.o
+*.d
 test
 tests


### PR DESCRIPTION
trezor/trezor-mcu#104 refactors the Makefile to use dependency files.
Because this repository does not ignore these files, git marks the
submodule as dirty.